### PR TITLE
CI: add asv check to CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pytest mypy
+          python -m pip install --upgrade pytest mypy asv
       - name: Install darshan-util
         run: |
           mkdir darshan_install
@@ -51,3 +51,8 @@ jobs:
           cd darshan-util/pydarshan
           mypy darshan
           mypy tests
+      - name: asv check
+        run: |
+          export LD_LIBRARY_PATH=$PWD/darshan_install/lib
+          cd darshan-util/pydarshan/benchmarks
+          python -m asv check -E existing


### PR DESCRIPTION
* add `asv check` run to CI, which imports and checks the basic
validity of the benchmark suite without wasting a bunch of time
running it

* takes about 3 seconds to do the check locally

* commonly used in the CI of other large Python projects; i.e.,
https://github.com/scipy/scipy/blob/master/ci/azure-travis-template.yaml#L154