### PR TITLE
TST, MAINT: logs repo resources

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,6 +38,18 @@ jobs:
         run: |
           cd darshan-util/pydarshan
           python -m pip install .
+      # shim for importlib.resources on Python < 3.9
+      - if: ${{matrix.python-version < 3.9}}
+        name: Install importlib_resources
+        run: |
+          python -m pip install -U importlib_resources
+      # only install the darshan_logs project in some CI
+      # entries so we test proper handling of skips
+      # in test suite
+      - if: ${{matrix.python-version != 3.8}}
+        name: Install darshan_logs package
+        run: |
+          python -m pip install git+https://github.com/darshan-hpc/darshan-logs.git@main
       - name: Test with pytest
         run: |
           export LD_LIBRARY_PATH=$PWD/darshan_install/lib

--- a/darshan-util/pydarshan/mypy.ini
+++ b/darshan-util/pydarshan/mypy.ini
@@ -30,6 +30,9 @@ ignore_missing_imports = True
 [mypy-darshan_logs]
 ignore_missing_imports = True
 
+[mypy-importlib_resources]
+ignore_missing_imports = True
+
 # pydarshan modules that lack types
 # or currently have errors
 

--- a/darshan-util/pydarshan/tests/conftest.py
+++ b/darshan-util/pydarshan/tests/conftest.py
@@ -1,3 +1,15 @@
+import platform
+python_version = platform.python_version_tuple()
+
+# shim for convenient Python 3.9 importlib.resources
+# interface
+if int(python_version[1]) < 9 and int(python_version[0]) == 3:
+    import importlib_resources
+else:
+    # see: https://github.com/python/mypy/issues/1153
+    import importlib.resources as importlib_resources # type: ignore
+
+
 import pytest
 
 try:
@@ -8,3 +20,15 @@ except ImportError:
 
 def pytest_configure():
     pytest.has_log_repo = has_log_repo
+
+@pytest.fixture
+def log_repo_files():
+    # provide a convenient way to access the list
+    # of all *.darshan log files in the logs repo,
+    # returning an empty list in the absence of the
+    # logs repo package and a list of absolute file
+    # paths to the logs otherwise
+    if not has_log_repo:
+        return []
+    p = importlib_resources.files('darshan_logs')
+    return [str(p) for p in p.glob('**/*.darshan')]

--- a/darshan-util/pydarshan/tests/test_report.py
+++ b/darshan-util/pydarshan/tests/test_report.py
@@ -21,6 +21,32 @@ def response():
     pass
 
 
+@pytest.mark.skipif(not pytest.has_log_repo, # type: ignore
+                    reason="missing darshan_logs")
+def test_jobid_type_all_logs_repo_files(log_repo_files):
+    # test for the expected jobid type in each of the
+    # log files in the darshan_logs package;
+    # this is primarily intended as a demonstration of looping
+    # through all logs repo files in a test
+    for log_filepath in log_repo_files:
+        # darshan_logs/apmpi/darshan-apmpi-2nodes-64mpi.darshan
+        # causes an issue so we skip it here:
+        # 
+        # Error: incompatible darshan file.
+        # Error: expected version 3.21, but got 
+        # <!
+        # Error: darshan_log_open failed to read darshan log file header: Undefined error: 0.
+        if 'darshan-apmpi-2nodes-64mpi' in log_filepath:
+            continue
+        # we also need to skip apmpi data for now to avoid
+        # a segfault on pydarshan-devel with current standard
+        # config/setup options (see the CI for example)
+        if 'apmpi_apxc' in log_filepath:
+            continue
+        report = darshan.DarshanReport(log_filepath)
+        assert isinstance(report.metadata['job']['jobid'], int)
+
+
 def test_metadata():
     """Sample for an expected property in counters."""
 


### PR DESCRIPTION
* provide a `pytest` fixture `log_repo_files()` that
returns a list of absolute paths for *all* files in the
`darshan_logs` package, and an empty list when this package
is absent

* add a demo test that leverages the new `log_repo_files()`
fixture, to make it easier for others to replicate this
kind of test that leverages all files in the logs repo; note
that some of the logs are large--overall test suite time jumps
from to 27.21s to 38.49s on a single core locally

* adjust CI such that it:
1) installs `importlib_resources` for testing on appropriate
Python versions
2) installs the `darshan_logs` project in some, but not all,
matrix entries, to ensure that tests can be skipped when this
package is missing