### PR TITLE
Filesystem Variables

### DIFF
--- a/darshan-util/pydarshan/darshan/experimental/plots/data_access_by_filesystem.py
+++ b/darshan-util/pydarshan/darshan/experimental/plots/data_access_by_filesystem.py
@@ -511,18 +511,18 @@ def plot_data(fig: Any,
         else:
             ax_filesystem_bytes.annotate(filesystem, (-0.3, 0.5), fontsize=fontsize, xycoords='axes fraction')
 
-        ax_filesystem_counts.barh(0, file_wr_series[filesystem], color='red', alpha=0.3)
-        ax_filesystem_counts.barh(1, file_rd_series[filesystem], color='blue', alpha=0.3)
+        ax_filesystem_counts.barh(0, files_written, color='red', alpha=0.3)
+        ax_filesystem_counts.barh(1, files_read, color='blue', alpha=0.3)
 
         ax_filesystem_bytes.text(0, 0.75, f' # bytes read ({bytes_read:.2E} MiB)', transform=ax_filesystem_bytes.transAxes)
         ax_filesystem_bytes.text(0, 0.25, f' # bytes written ({bytes_written:.2E} MiB)', transform=ax_filesystem_bytes.transAxes)
 
-        if file_rd_series[filesystem] == 0:
+        if files_read == 0:
             ax_filesystem_counts.text(0, 0.75, ' 0 files read', transform=ax_filesystem_counts.transAxes)
         else:
             ax_filesystem_counts.text(0, 0.75, f' # files read ({files_read:.2E})', transform=ax_filesystem_counts.transAxes)
 
-        if file_wr_series[filesystem] == 0:
+        if files_written == 0:
             ax_filesystem_counts.text(0, 0.25, ' 0 files written', transform=ax_filesystem_counts.transAxes)
         else:
             ax_filesystem_counts.text(0, 0.25, f' # files written ({files_written:.2E})', transform=ax_filesystem_counts.transAxes)


### PR DESCRIPTION
Use assigned filesystem variables "files_read" and "files_written"
instead of multiple instances of series indexing.