### PR TITLE
MiB Test Fix

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - pydarshan-devel
+      - pydarshan-MiB
   pull_request:
     branches:
       - pydarshan-devel
+      - pydarshan-MiB
 
 jobs:
   test_pydarshan:
@@ -45,7 +47,7 @@ jobs:
           python setup.py install
       - name: Test with pytest
         run: |
-          export LD_LIBRARY_PATH=$PWD/darshan_install/lib
+          export LD_LIBRARY_PATH=/home/jacobdickens/darshan_install/lib
           # the test suite is sensitive to
           # relative dir for test file paths
           cd darshan-util/pydarshan

--- a/darshan-util/pydarshan/tests/test_data_access_by_filesystem.py
+++ b/darshan-util/pydarshan/tests/test_data_access_by_filesystem.py
@@ -423,7 +423,7 @@ def test_plot_data_shared_x_axis():
     rd_file_cts = [1e3, 1e4, 1e5, 1e6]
     wr_file_cts = [1e2, 1e3, 1e4, 1e5]
     # multiply by the MiB conversion factor to get round numbers in the output
-    factor = 1.049e+6
+    factor = 1048576
     bytes_rd_series = pd.Series(data=rd_bytes, index=filesystem_roots) * factor
     bytes_wr_series = pd.Series(data=wr_bytes, index=filesystem_roots) * factor
     file_rd_series = pd.Series(data=rd_file_cts, index=filesystem_roots)


### PR DESCRIPTION
Updated the plot test to reflect the change in MiB conversion from
an estimation to actual (1.049e+6 -> 1048576)
Now passes ``pyflake check`` when tested locally.